### PR TITLE
fix getPlatformVariant, getHumanPlatform and getBinaryPath

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -263,7 +263,7 @@ function getBinaryPath() {
   } else if (pkg.nodeSassConfig && pkg.nodeSassConfig.binaryPath) {
     binaryPath = pkg.nodeSassConfig.binaryPath;
   } else {
-    binaryPath = path.join(defaultBinaryPath, getBinaryName().replace(/_(?=binding\.node)/, '/', '/'));
+    binaryPath = path.join(defaultBinaryPath, getBinaryName().replace(/_(?=binding\.node)/, '/'));
   }
 
   return binaryPath;

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -23,6 +23,7 @@ function getHumanPlatform(platform) {
     case 'darwin': return 'OS X';
     case 'freebsd': return 'FreeBSD';
     case 'linux': return 'Linux';
+    case 'linux_musl': return 'Linux/musl';
     case 'win32': return 'Windows';
     default: return false;
   }
@@ -262,7 +263,7 @@ function getBinaryPath() {
   } else if (pkg.nodeSassConfig && pkg.nodeSassConfig.binaryPath) {
     binaryPath = pkg.nodeSassConfig.binaryPath;
   } else {
-    binaryPath = path.join(defaultBinaryPath, getBinaryName().replace(/_/, '/'));
+    binaryPath = path.join(defaultBinaryPath, getBinaryName().replace(/_(?=binding\.node)/, '/', '/'));
   }
 
   return binaryPath;
@@ -377,7 +378,7 @@ function getPlatformVariant() {
   }
   var contents = '';
   try {
-    contents = fs.readFileSync('foo.bar');
+    contents = fs.readFileSync(process.execPath);
     if (!contents.indexOf) {
       contents = contents.toString();
     }


### PR DESCRIPTION
Hey @lox,

I've fixed a few more issues that you'd hit with the musl build and managed to get them passing on CI.

1. change `contents = fs.readFileSync('foo.bar');` to `contents = fs.readFileSync(process.execPath);` - that's just a bug

2. `function getHumanPlatform` - add `linux_musl` otherwise it will return false and it'll fail on `isSupportedEnvironment()`

3. `function getBinaryPath()` - change `.replace(/_/, '/')` to `.replace(/_(?=binding\.node)/, '/', '/')` or it'll try to find binaries in an inexistent path because `linux_musl` is the first `_` that it replaces.